### PR TITLE
Allow customizing the popup notification title

### DIFF
--- a/src/main/java/com/twitchliveloadout/marketplace/notifications/NotificationManager.java
+++ b/src/main/java/com/twitchliveloadout/marketplace/notifications/NotificationManager.java
@@ -213,11 +213,12 @@ public class NotificationManager {
 			return;
 		}
 
+		var hasCustomTitle = null != notification.ebsNotification.popupTitle;
 		plugin.runOnClientThread(() -> {
 			try {
 				String message = getMessage(notification);
 				WidgetNode widgetNode = client.openInterface((161 << 16) | 13, 660, WidgetModalMode.MODAL_CLICKTHROUGH);
-				client.runScript(3343, POPUP_NOTIFICATION_TITLE, message, -1);
+				client.runScript(3343, hasCustomTitle ? notification.ebsNotification.popupTitle : POPUP_NOTIFICATION_TITLE, message, -1);
 
 				plugin.runOnClientThread(() -> {
 					Widget w = client.getWidget(660, 1);

--- a/src/main/java/com/twitchliveloadout/marketplace/products/EbsNotification.java
+++ b/src/main/java/com/twitchliveloadout/marketplace/products/EbsNotification.java
@@ -6,4 +6,5 @@ public class EbsNotification {
 	public String messageType = NONE_NOTIFICATION_MESSAGE_TYPE;
 	public String message;
 	public Boolean queue = true;
+	public String popupTitle = null;
 }


### PR DESCRIPTION
Now that popup notifications is a thing, it would be nice to be able to customize the title.
This change opens up notifications to provide a `popupTitle` property in their json output which will replace the default (which is "Live Loadout")

![image](https://github.com/pepijnverburg/osrs-runelite-twitch-live-loadout-plugin/assets/8125386/e4c6757f-0a3a-4263-9370-214de0303045)
